### PR TITLE
Add custom Sentry tags for better troubleshooting

### DIFF
--- a/src/app/games/snake/page.tsx
+++ b/src/app/games/snake/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { useSession } from 'next-auth/react'
 import Link from 'next/link'
+import { setSentryGameType, clearSentryGameTags } from '@/lib/sentry'
 
 type Direction = 'up' | 'down' | 'left' | 'right'
 type Position = { x: number; y: number }
@@ -22,6 +23,12 @@ export default function SnakePage() {
   const directionRef = useRef<Direction>('right')
   const gameLoopRef = useRef<NodeJS.Timeout | null>(null)
   const cellSizeRef = useRef(10)
+
+  // Set Sentry game tags
+  useEffect(() => {
+    setSentryGameType('SNAKE')
+    return () => clearSentryGameTags()
+  }, [])
 
   // Check if mobile
   useEffect(() => {

--- a/src/app/games/tetris/page.tsx
+++ b/src/app/games/tetris/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { useSession } from 'next-auth/react'
 import Link from 'next/link'
+import { setSentryGameType, clearSentryGameTags } from '@/lib/sentry'
 
 const SHAPES = [
   [[1, 1, 1, 1]],                    // I
@@ -35,6 +36,12 @@ export default function TetrisPage() {
   const [gameState, setGameState] = useState<'idle' | 'playing' | 'paused' | 'gameover'>('idle')
   const [playerName, setPlayerName] = useState('')
   const [isMobile, setIsMobile] = useState(false)
+
+  // Set Sentry game tags
+  useEffect(() => {
+    setSentryGameType('TETRIS')
+    return () => clearSentryGameTags()
+  }, [])
 
   // Check if mobile
   useEffect(() => {

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -3,11 +3,13 @@
 import { SessionProvider } from 'next-auth/react'
 import { ReactNode } from 'react'
 import { AutoGuestLogin } from './AutoGuestLogin'
+import { SentryUserContext } from './SentryUserContext'
 
 export function Providers({ children }: { children: ReactNode }) {
   return (
     <SessionProvider>
       <AutoGuestLogin />
+      <SentryUserContext />
       {children}
     </SessionProvider>
   )

--- a/src/components/SentryUserContext.tsx
+++ b/src/components/SentryUserContext.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useSession } from 'next-auth/react'
+import { useEffect, useRef } from 'react'
+import { setSentryUserTags, setSentryAuthProvider, type AuthProvider } from '@/lib/sentry'
+
+/**
+ * SentryUserContext - Automatically sets Sentry user tags based on session
+ *
+ * This component should be placed inside the SessionProvider to automatically
+ * update Sentry tags whenever the user's session changes.
+ *
+ * Tags set:
+ * - user_type: 'authenticated' | 'guest' | 'anonymous'
+ * - user_role: 'USER' | 'ADMIN'
+ * - auth_provider: OAuth provider used for authentication
+ */
+export function SentryUserContext() {
+  const { data: session, status } = useSession()
+  const previousSessionId = useRef<string | null>(null)
+
+  useEffect(() => {
+    // Skip if session is still loading
+    if (status === 'loading') return
+
+    // Get current user ID (or null for unauthenticated)
+    const currentUserId = session?.user?.id ?? null
+
+    // Only update if session actually changed
+    if (currentUserId === previousSessionId.current) return
+    previousSessionId.current = currentUserId
+
+    if (session?.user) {
+      // Set user tags
+      setSentryUserTags({
+        id: session.user.id,
+        email: session.user.email,
+        role: session.user.role,
+        isGuest: session.user.isGuest,
+      })
+
+      // Determine auth provider from user ID pattern
+      // Guest users have IDs like "guest_uuid"
+      if (session.user.isGuest) {
+        setSentryAuthProvider('guest')
+      }
+      // For OAuth users, the provider info is not directly available in session
+      // It would be set during the sign-in flow
+    } else {
+      // User is not authenticated
+      setSentryUserTags(null)
+    }
+  }, [session, status])
+
+  // This component doesn't render anything
+  return null
+}

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,0 +1,122 @@
+/**
+ * Sentry Utility Functions for Custom Tags
+ *
+ * Custom tags help with issue troubleshooting by providing filterable context:
+ * - user_type: Distinguishes between authenticated users, guests, and anonymous visitors
+ * - user_role: Identifies admin vs regular users for permission-related issues
+ * - auth_provider: Tracks which OAuth provider was used for auth-related bugs
+ * - feature_area: Categorizes errors by application feature for faster triage
+ * - game_type: Identifies which game is being played for game-specific issues
+ */
+
+import * as Sentry from '@sentry/nextjs'
+
+// User type values
+export type UserType = 'authenticated' | 'guest' | 'anonymous'
+
+// User role values (matches Prisma schema)
+export type UserRole = 'USER' | 'ADMIN'
+
+// Auth provider values
+export type AuthProvider = 'google' | 'github' | 'azure-ad' | 'apple' | 'guest' | 'unknown'
+
+// Feature area values for categorizing errors
+export type FeatureArea = 'games' | 'blog' | 'admin' | 'api' | 'auth' | 'tools' | 'home'
+
+// Game type values
+export type GameType = 'SNAKE' | 'TETRIS'
+
+/**
+ * Set user-related Sentry tags based on session data
+ * Call this when user session changes (login, logout, session refresh)
+ */
+export function setSentryUserTags(user: {
+  id?: string
+  email?: string | null
+  role?: UserRole
+  isGuest?: boolean
+} | null): void {
+  if (!user) {
+    // Anonymous user (not logged in)
+    Sentry.setTag('user_type', 'anonymous')
+    Sentry.setTag('user_role', undefined)
+    Sentry.setTag('auth_provider', undefined)
+    Sentry.setUser(null)
+    return
+  }
+
+  // Set user type
+  const userType: UserType = user.isGuest ? 'guest' : 'authenticated'
+  Sentry.setTag('user_type', userType)
+
+  // Set user role
+  Sentry.setTag('user_role', user.role || 'USER')
+
+  // Set Sentry user context (for issue assignment and user impact)
+  Sentry.setUser({
+    id: user.id,
+    email: user.email || undefined,
+  })
+}
+
+/**
+ * Set the auth provider tag
+ * Call this after successful authentication to track which provider was used
+ */
+export function setSentryAuthProvider(provider: AuthProvider): void {
+  Sentry.setTag('auth_provider', provider)
+}
+
+/**
+ * Set the feature area tag
+ * Call this when entering a specific feature area of the application
+ */
+export function setSentryFeatureArea(area: FeatureArea): void {
+  Sentry.setTag('feature_area', area)
+}
+
+/**
+ * Set the game type tag
+ * Call this when a user starts playing a specific game
+ */
+export function setSentryGameType(gameType: GameType): void {
+  Sentry.setTag('game_type', gameType)
+  Sentry.setTag('feature_area', 'games')
+}
+
+/**
+ * Clear game-specific tags
+ * Call this when user leaves a game
+ */
+export function clearSentryGameTags(): void {
+  Sentry.setTag('game_type', undefined)
+}
+
+/**
+ * Set API-related tags for server-side error tracking
+ * Call this in API routes for better error categorization
+ */
+export function setSentryApiTags(options: {
+  endpoint: string
+  method: string
+  isAdminOnly?: boolean
+}): void {
+  Sentry.setTag('feature_area', 'api')
+  Sentry.setTag('api_endpoint', options.endpoint)
+  Sentry.setTag('api_method', options.method)
+  if (options.isAdminOnly !== undefined) {
+    Sentry.setTag('api_admin_only', options.isAdminOnly ? 'true' : 'false')
+  }
+}
+
+/**
+ * Set integration-related tags for admin dashboard integrations
+ * Call this when making external API calls to third-party services
+ */
+export function setSentryIntegrationTags(options: {
+  integrationName: 'sentry' | 'vercel' | 'cloudflare' | 'neon' | 'github' | 'uptimerobot' | 'cloudinary'
+  operationType: 'fetch' | 'update' | 'sync' | 'delete'
+}): void {
+  Sentry.setTag('integration_name', options.integrationName)
+  Sentry.setTag('integration_operation', options.operationType)
+}


### PR DESCRIPTION
Add utility functions and components to set custom Sentry tags:
- user_type: authenticated/guest/anonymous
- user_role: USER/ADMIN
- auth_provider: OAuth provider used
- feature_area: games/blog/admin/api/auth/tools
- game_type: SNAKE/TETRIS (when playing games)

Tags are automatically set via SentryUserContext on session changes and manually in game pages for game-specific context.