### PR TITLE
Restrict Sentry Test page to admin access

### DIFF
--- a/src/app/sentry-example-page/page.tsx
+++ b/src/app/sentry-example-page/page.tsx
@@ -1,10 +1,41 @@
 "use client";
 
 import * as Sentry from "@sentry/nextjs";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 const { logger } = Sentry;
 
 export default function SentryExamplePage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (status === "loading") return;
+    if (!session?.user || session.user.role !== "ADMIN") {
+      router.push("/");
+    }
+  }, [session, status, router]);
+
+  // Show loading state while checking auth
+  if (status === "loading") {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-gray-600 dark:text-gray-400">Loading...</div>
+      </div>
+    );
+  }
+
+  // Don't render content if not admin
+  if (!session?.user || session.user.role !== "ADMIN") {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-gray-600 dark:text-gray-400">Redirecting...</div>
+      </div>
+    );
+  }
+
   const handleTestError = () => {
     Sentry.startSpan(
       {


### PR DESCRIPTION
Add authentication check to the Sentry example page following the same pattern used by other admin pages. Non-admin users are now redirected to the home page.